### PR TITLE
Add compile guards to C version

### DIFF
--- a/C/FastNoiseLite.h
+++ b/C/FastNoiseLite.h
@@ -49,6 +49,9 @@
 
 // In *one* C or C++ file, use #define FNL_IMPL to generate implementation
 
+#ifndef FASTNOISELITE_H
+#define FASTNOISELITE_H
+
 // Switch between using floats or doubles for input position
 typedef float FNLfloat;
 //typedef double FNLfloat;
@@ -2426,3 +2429,5 @@ void fnlDomainWarp3D(fnl_state *state, FNLfloat *x, FNLfloat *y, FNLfloat *z)
 #if defined(__cplusplus)
 }
 #endif
+
+#endif FASTNOISELITE_H


### PR DESCRIPTION
This will prevent compilation errors when including the library multiple times.